### PR TITLE
added check if url has protocol included

### DIFF
--- a/src/components/results/ResultItem.js
+++ b/src/components/results/ResultItem.js
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types';
 
 function ResultItem(props) {
   const { name, provider, url, link, summary } = props;
+  const externalLink =
+    link.indexOf('http://') === 0 || link.indexOf('https://') === 0 ? link : `//${link}`;
+
   return (
     <>
       <article className="wdgt">
@@ -10,7 +13,7 @@ function ResultItem(props) {
         <ul>
           <li>
             <span className="highlight">Provider </span>
-            <a className="btn-secondary" href={link}>
+            <a className="btn-secondary" href={externalLink}>
               {provider}
             </a>
             <i className="icon-link-external icon-large" />


### PR DESCRIPTION
Some of the URLs for the provider are set without https:// which append the link to the current domain. example: https://beta.wmca.org.uk/what-we-do/covid-19-support/online-resources/www.tesco-careers.com. There was a similar issue with the only email address being added instead of a link.